### PR TITLE
use relative links to support hns domain

### DIFF
--- a/browser/privacy.html
+++ b/browser/privacy.html
@@ -34,7 +34,7 @@
 <!-- Hero -->
 <div class="container">
     <div class="hero">
-        <a href="https://impervious.com"><img src="../images/logo.svg" class="logo" alt="Impervious"/></a>
+        <a href="/"><img src="../images/logo.svg" class="logo" alt="Impervious"/></a>
         <h3>Privacy Policy</h3>
         <h5>Last modified November 12, 2021</h5>
         <div style="text-align: left;margin-top:2em">

--- a/browser/terms-of-use.html
+++ b/browser/terms-of-use.html
@@ -37,7 +37,7 @@
 <!-- Hero -->
 <div class="container">
     <div class="hero">
-        <a href="https://impervious.com"><img src="../images/logo.svg" class="logo" alt="Impervious"/></a>
+        <a href="/"><img src="../images/logo.svg" class="logo" alt="Impervious"/></a>
         <h3>Terms of Use</h3>
         <h5>Last modified November 12, 2021</h5>
         <div style="text-align: left;margin-top:2em">

--- a/fingertip.html
+++ b/fingertip.html
@@ -68,7 +68,7 @@
 <!-- Hero -->
 <div class="container">
     <div class="hero">
-        <a href="https://impervious.com"><img src="images/logo.svg" class="logo" alt="Impervious"/></a>
+        <a href="/"><img src="images/logo.svg" class="logo" alt="Impervious"/></a>
 
         <h1>Fingertip</h1>
         <p>An experimental <a style="text-decoration: none;" href="https://github.com/imperviousinc/fingertip">open source</a>

--- a/index.html
+++ b/index.html
@@ -113,8 +113,8 @@
            <h5>Projects</h5>
            <p><a href="https://foreverdomains.io">.forever Domains</a></p>
            <p><a href="https://badass.domains">.badass Domains</a></p>
-           <p><a href="https://impervious.com/fingertip">Fingertip</a></p>
-           <p><a href="https://impervious.com/beacon">Beacon</a></p>
+           <p><a href="/fingertip">Fingertip</a></p>
+           <p><a href="/beacon">Beacon</a></p>
          </div>
         </div>
       </div>


### PR DESCRIPTION
Use relative links where applicable so if a user is browsing at `https://impervious` and click other website links, they stay on the HNS domain.